### PR TITLE
Don't show a file save dialog when saving images

### DIFF
--- a/background.js
+++ b/background.js
@@ -190,7 +190,7 @@ function downloadImage(image, tabid, callback) {
 	var downloading = browser.downloads.download({
 		url: url,
 		filename: path,
-		//saveAs: false, // not required, min_ver FF52
+		saveAs: false, // required as of FF58
 		conflictAction: CONFLICT_ACTION
 	});
 	downloading.then(


### PR DESCRIPTION
Don't show the file save dialog when saving images (fix for FF58)