### PR TITLE
Add checkbox to use image "alt" attribute for file name

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -31,6 +31,8 @@ function getOptions(callback) {
     DOWNLOAD_PATH = result.downloadPath || "";
     if (DOWNLOAD_PATH.length > 0) {DOWNLOAD_PATH += "/";}
     CONFLICT_ACTION = result.conflictAction || "uniquify";
+    ALT_IS_FILENAME = result.altIsFilename;
+    ALT_FILENAME_EXT = result.altFilenameExt;
     MIN_WIDTH = result.minWidth || "100";
     MIN_HEIGHT = result.minHeight || "100";
     if (result.notifyEnded === null) {result.notifyEnded = true;}
@@ -176,26 +178,34 @@ function download(url, path, tabid) {
 }
 
 /* now using XHR for filename */
-function downloadXhr(url, tabid) {
+function downloadXhr(image, tabid) {
   let xhrCallback = (function() { // catches events for: load, error, abort
     let filename = "";
-    let disposition = this.getResponseHeader("Content-Disposition");
-    if (disposition && disposition.indexOf("filename") !== -1) {
-      let filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
-      let matches = filenameRegex.exec(disposition);
-      if (matches !== null && matches[1]) {
-        filename = matches[1].replace(/['"]/g, "");
+    if (ALT_IS_FILENAME && image.alt)
+      // append filename from alt attribute and filename extension
+      filename = image.alt + ALT_FILENAME_EXT;
+
+    if (!isValidFilename(filename)) {
+      let disposition = this.getResponseHeader("Content-Disposition");
+      if (disposition && disposition.indexOf("filename") !== -1) {
+	let filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+	let matches = filenameRegex.exec(disposition);
+	if (matches !== null && matches[1]) {
+	  filename = matches[1].replace(/['"]/g, "");
+	}
       }
     }
+
     console.log(`XHR Filename: ${filename}`);
+    console.log(`XHR URL: ${image.src}`);
     if (!isValidFilename(filename)) {
       // no filename found, so create filename from url
-      filename = url.replace(/^.*[/\\]/, "");
+      filename = image.src.replace(/^.*[/\\]/, "");
       filename = filename.replace(/\?.*/, ""); // Remove query string
       filename = filename.replace(/:.*/, ""); // Workaround for Twitter
       if (!isValidFilename(filename)) {
         // no filename found from url, so use domain+path as filename
-        filename = url.replace(/\?.*/, ""); // Remove query string
+        filename = image.src.replace(/\?.*/, ""); // Remove query string
         filename = filename.replace(/:.*/, ""); // Workaround for Twitter
         filename = filename.replace(/[*"/\\:<>|?]/g, "_"); // Remove invalid characters
         // TODO if still no valid filename
@@ -205,10 +215,10 @@ function downloadXhr(url, tabid) {
     }
     let path = DOWNLOAD_PATH;
     path += filename;
-    download(url, path, tabid);
+    download(image.src, path, tabid);
   });
   let xhr = new XMLHttpRequest();
-  xhr.open("HEAD", url);
+  xhr.open("HEAD", image.src);
   xhr.addEventListener("loadend", xhrCallback);
   xhr.send();
   return true;
@@ -228,7 +238,7 @@ function downloadImages(images, tabid) {
       IMAGES_FAILED++;
       console.log("Image is embedded"); // TODO support embedded
     } else {
-      downloadXhr(url, tabid);
+      downloadXhr(image, tabid);
     }
   }
   return true;

--- a/addon/background.js
+++ b/addon/background.js
@@ -152,7 +152,7 @@ function onDownloadFailed(e, path) {
 }
 
 function isValidFilename(filename) {
-  return (filename.length > 0) && (!/[*"/\\:<>|?]/.test(filename));
+  return (filename.length > 0) && (!/[*\"/\\:<>|?]/.test(filename));
 }
 
 /* do the download */

--- a/addon/content-maximage.js
+++ b/addon/content-maximage.js
@@ -15,7 +15,8 @@
     }
     // Check if an image has been found.
     if (maxImage) {
-      return [{src: maxImage.src}];
+      return [{src: maxImage.src,
+	       alt: maxImage.alt}];
     }
     return null;
   }

--- a/addon/content-tabimage.js
+++ b/addon/content-tabimage.js
@@ -5,7 +5,8 @@
       maxImage = document.images[0];
     }
     if (maxImage && maxImage.width >= window.MIN_WIDTH && maxImage.height >= window.MIN_HEIGHT) {
-      return [{src: maxImage.src}];
+      return [{src: maxImage.src,
+	       alt: maxImage.alt}];
     }
     return null;
   }

--- a/addon/options.html
+++ b/addon/options.html
@@ -15,7 +15,7 @@
 	<label><input type="radio" name="action" value="right" id="action_right" >Right of current tab</label>
 	<label><input type="radio" name="action" value="all" id="action_all" >All tabs</label>
 
-<p>
+	<br/>
       <label><input type="checkbox" id="activeTab" >Include current tab</label>
 </p>
 <p>
@@ -30,8 +30,7 @@
       <label>Width
       <input type="text" id="minWidth" >
       </label>
-</p>
-<p>
+      <br/>
       <label>Height
       <input type="text" id="minHeight" >
       </label>
@@ -39,7 +38,7 @@
 <p>
 <legend>Images are saved in your Downloads path.<br>Optionally you can name a subfolder to save into.</legend>
       <label>Folder
-      <input type="text" id="downloadPath" >
+      <input type="text" id="downloadPath" size="60">
       </label>
 </p>
 <p>
@@ -50,11 +49,9 @@
 <p>
 	<legend>Advanced options</legend>
       <label><input type="checkbox" id="closeTab" >Close tabs after saving</label>
-</p>
-<p>
+      <br/>
       <label><input type="checkbox" id="notifyEnded" >Show notification popups</label>
-</p>
-<p>
+      <br/>
       <label><input type="checkbox" id="removeEnded" >Incognito mode</label> (hide from download history)
 </p>
   </form>

--- a/addon/options.html
+++ b/addon/options.html
@@ -42,6 +42,18 @@
       </label>
 </p>
 <p>
+      <legend>Use image "alt" attribute for save file name, if available</legend>
+      <label>
+	<input type="checkbox" id="altIsFilename">
+	Use "alt" attribute for filename
+      </label>
+      <br/>
+      <label>
+	Optionally add file extension (e.g. ".jpg")
+	<input type="text" id="altFilenameExt"/>
+      </label>
+</p>
+<p>
 	<legend>Duplicate filename action</legend>
 	<label><input type="radio" name="conflictAction" value="uniquify" id="conflictAction_uniquify" >Rename (automatic)</label>
 	<label><input type="radio" name="conflictAction" value="overwrite" id="conflictAction_overwrite" >Overwrite</label>

--- a/addon/options.js
+++ b/addon/options.js
@@ -11,10 +11,12 @@ function saveOptions(e) {
     closeTab: document.querySelector("#closeTab").checked,
     notifyEnded: document.querySelector("#notifyEnded").checked,
     removeEnded: document.querySelector("#removeEnded").checked,
+    altIsFilename: document.querySelector("#altIsFilename").checked,
     // text
     downloadPath: document.querySelector("#downloadPath").value.replace(/^[/\\]+|[/\\]+$/g, ""), // remove leading and trailing slashes
     minWidth: document.querySelector("#minWidth").value,
-    minHeight: document.querySelector("#minHeight").value
+    minHeight: document.querySelector("#minHeight").value,
+    altFilenameExt: document.querySelector("#altFilenameExt").value
   });
 }
 
@@ -43,8 +45,10 @@ function restoreOptions() {
     }
     document.querySelector("#notifyEnded").checked = result.notifyEnded;
     document.querySelector("#removeEnded").checked = result.removeEnded;
+    document.querySelector("#altIsFilename").checked = result.altIsFilename;
     // text
     document.querySelector("#downloadPath").value = result.downloadPath || "";
+    document.querySelector("#altFilenameExt").value = result.altFilenameExt || "";
     document.querySelector("#minWidth").value = result.minWidth || "100";
     document.querySelector("#minHeight").value = result.minHeight || "100";
   }


### PR DESCRIPTION
Add checkbox to use image "alt" attribute for file name

Some image elements have meaningless file names but descriptive "alt"
image attributes, for example:

```<img src="http://example.com/620918775623.jpg" alt="Image17"/>```

This commit adds the option to use the image's "alt" attribute for the
file name, and optionally add a filename extension (like ".jpg"), so
that "620918775623.jpg" may be saved as "Image17.jpg".

If the option is enabled but there is no "alt" attribute, the original
behavior is preserved.

-----
Also tweak options page formatting.

Nice extension, thanks!